### PR TITLE
Fix for Project Group Show endpoint data.

### DIFF
--- a/resources/project_group.md
+++ b/resources/project_group.md
@@ -101,13 +101,6 @@ status 200 OK
     "data": {
         "id": 365,
         "name": "Travel Magazine",
-        "base_language": {
-            "code": "en-US",
-            "english_name": "English (United States)",
-            "local_name": "English (United States)",
-            "locale": "en",
-            "region" : "US"
-        },
         "enabled_language_count": 3,
         "project_count": 6
     }


### PR DESCRIPTION
I've noticed that **Show** endpoint of Project Group doesn't return `base_language` field. So I removed this field from documentation.
(Based on actual response from API)