### PR TITLE
Translation App description samples

### DIFF
--- a/reference/translation_app_description_samples.md
+++ b/reference/translation_app_description_samples.md
@@ -1,4 +1,10 @@
 ## Response samples of app description
+- [iTunes App Store](#itunes-app-store)
+- [Google Play](#google-play)
+- [Windows Phone Store](#windows-phone-store)
+- [Amazon Appstore](#amazon-appstore)
+- [Samsung Apps](#samsung-apps)
+- [Facebook App Center](#facebook-app-center)
 
 ### iTunes App Store
 ``` json
@@ -32,6 +38,7 @@
 	}
 }
 ```
+[Back to top](#response-samples-of-app-description)
 
 ### Google Play
 ``` json
@@ -62,6 +69,7 @@
 	}
 }
 ```
+[Back to top](#response-samples-of-app-description)
 
 ### Windows Phone Store
 ``` json
@@ -87,6 +95,7 @@
 	}
 }
 ```
+[Back to top](#response-samples-of-app-description)
 
 ### Amazon Appstore
 ``` json
@@ -113,6 +122,7 @@
 	}
 }
 ```
+[Back to top](#response-samples-of-app-description)
 
 ### Samsung Apps
 ``` json
@@ -137,6 +147,7 @@
 	}
 }
 ```
+[Back to top](#response-samples-of-app-description)
 
 ### Facebook App Center
 ``` json
@@ -159,3 +170,4 @@
 	}
 }
 ```
+[Back to top](#response-samples-of-app-description)

--- a/reference/translation_app_description_samples.md
+++ b/reference/translation_app_description_samples.md
@@ -1,0 +1,161 @@
+## Response samples of app description
+
+### iTunes App Store
+``` json
+{
+    "meta": {
+        "status": 200,
+        "language": {
+            "code": "en-US",
+            "english_name": "English (United States)",
+            "local_name": "English (United States)",
+            "locale": "en",
+            "region" : "US"
+        }
+    },
+    "data": {
+	    "APP_NAME": "App Name",
+	    "APP_DESCRIPTION": "Description",
+	    "APP_VERSION_DESCRIPTION": "New in this Version",
+	    "APP_KEYWORD": {
+	        "Keyword1": "Keyword 1",
+	        "Keyword2": "Keyword 2"
+	    },
+	    "APP_IAP_NAME": {
+	        "iap_product1": "Product 1",
+	        "iap_product2": "Product 2"
+	    },
+	    "APP_IAP_DESCRIPTION": {
+	        "iap_product1": "Product 1 description",
+	        "iap_product2": "Product 2 description"
+	    }
+	}
+}
+```
+
+### Google Play
+``` json
+{
+    "meta": {
+        "status": 200,
+        "language": {
+            "code": "en-US",
+            "english_name": "English (United States)",
+            "local_name": "English (United States)",
+            "locale": "en",
+            "region" : "US"
+        }
+    },
+    "data": {
+	    "TITLE": "Title",
+	    "DESCRIPTION": "Description",
+	    "RECENT_CHANGES": "Recent Changes",
+	    "SHORT_DESCRIPTION": "Short Description",
+	    "APP_IAP_NAME": {
+	        "iap_product1": "Product 1",
+	        "iap_product2": "Product 2"
+	    },
+	    "APP_IAP_DESCRIPTION": {
+	        "iap_product1": "Product 1 description",
+	        "iap_product2": "Product 2 description"
+	    }
+	}
+}
+```
+
+### Windows Phone Store
+``` json
+{
+    "meta": {
+        "status": 200,
+        "language": {
+            "code": "en-US",
+            "english_name": "English (United States)",
+            "local_name": "English (United States)",
+            "locale": "en",
+            "region" : "US"
+        }
+    },
+    "data": {
+	    "APP_NAME": "Application Name",
+	    "DETAILED_DESCRIPTION": "Detailed Description",
+	    "SHORT_DESCRIPTION": "Short Description",
+	    "KEYWORDS": {
+	        "Keyword1": "Keyword 1",
+	        "Keyword2": "Keyword 2"
+	    }
+	}
+}
+```
+
+### Amazon Appstore
+``` json
+{
+    "meta": {
+        "status": 200,
+        "language": {
+            "code": "en-US",
+            "english_name": "English (United States)",
+            "local_name": "English (United States)",
+            "locale": "en",
+            "region" : "US"
+        }
+    },
+    "data": {
+	    "AMAZON_APPSTORE_TITLE": "Displaying Title",
+	    "AMAZON_APPSTORE_SHORT_DESCRIPTION": "Short Description",
+	    "AMAZON_APPSTORE_LONG_DESCRIPTION": "Long Description",
+	    "AMAZON_APPSTORE_FEATURE_BULLETS": "iap_productFeatures",
+	    "AMAZON_APPSTORE_KEYWORDS": {
+	        "Keyword1": "Keyword 1",
+	        "Keyword2": "Keyword 2"
+	    }
+	}
+}
+```
+
+### Samsung Apps
+``` json
+{
+    "meta": {
+        "status": 200,
+        "language": {
+            "code": "en-US",
+            "english_name": "English (United States)",
+            "local_name": "English (United States)",
+            "locale": "en",
+            "region" : "US"
+        }
+    },
+    "data": {
+	    "TITLE": "Title",
+	    "DESCRIPTION": "Description",
+	    "APP_TAG": {
+	        "Tag1": "Tag 1",
+	        "Tag2": "Tag 2"
+	    }
+	}
+}
+```
+
+### Facebook App Center
+``` json
+{
+    "meta": {
+        "status": 200,
+        "language": {
+            "code": "en-US",
+            "english_name": "English (United States)",
+            "local_name": "English (United States)",
+            "locale": "en",
+            "region" : "US"
+        }
+    },
+    "data": {
+	    "DISPLAY_NAME": "App Name",
+	    "DETAILED_DESCRIPTION": "Long Description",
+	    "DESCRIPTION": "Short Description",
+	    "TAGLINE": "Tagline"
+	}
+}
+```

--- a/resources/translation.md
+++ b/resources/translation.md
@@ -129,6 +129,9 @@ status 200 OK
     }
 }
 ```
+Remark:
+- Response `data` may vary based on application type. Samples [here](/reference/translation_app_description_samples.md).
+
 [Back to top](#translation)
 
 


### PR DESCRIPTION
Different app stores have different response `data`.
It may not be a problem to dome one, but as for me I'd rather add examples of those responses to documentation.

PS. Note that new page missing 'Nokia Store' response example - I failed to create 'Nokia Store' project via website (step2 has no inputs whatsoever).