### PR TITLE
Fix name of the Symfony framework in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ For more authentication error troubleshooting, please see this [article](https:/
 **PHP**
 - [api-library-php5](https://github.com/onesky/api-library-php5) - OneSky
 
-**PHP Symphony**
+**PHP Symfony**
 - [OneSkyBundle](https://github.com/OpenClassrooms/OneSkyBundle) - OpenClassrooms
 
 **Python**


### PR DESCRIPTION
It seems there is a typo in the PHP framework name. See https://symfony.com/.